### PR TITLE
Restrict admin-only pages

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -34,14 +34,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.thymeleaf.extras</groupId>
+                        <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.mialquiler.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails admin = User.withDefaultPasswordEncoder()
+                .username("admin")
+                .password("password")
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(admin);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/", "/login").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(withDefaults())
+            .logout(withDefaults());
+        return http.build();
+    }
+}

--- a/demo/src/main/java/com/mialquiler/demo/controller/PropiedadController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/PropiedadController.java
@@ -5,11 +5,13 @@ import com.mialquiler.demo.repository.UserRepository;
 import com.mialquiler.demo.service.PropiedadService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/propiedades")
+@PreAuthorize("hasRole('ADMIN')")
 public class PropiedadController {
 
     @Autowired

--- a/demo/src/main/java/com/mialquiler/demo/controller/UserController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/UserController.java
@@ -5,11 +5,13 @@ import com.mialquiler.demo.repository.UserRepository;
 import com.mialquiler.demo.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/users")
+@PreAuthorize("hasRole('ADMIN')")
 public class UserController {
 
     @Autowired

--- a/demo/src/main/resources/templates/index.html
+++ b/demo/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <head>
     <meta charset="UTF-8">
     <title>MiAlquiler - Dashboard</title>
@@ -15,8 +15,8 @@
         <i class="fas fa-home"></i> MiAlquiler
     </a>
     <div class="navbar-nav ml-auto">
-        <a class="nav-link" href="/users/all"><i class="fas fa-users"></i> Usuarios</a>
-        <a class="nav-link" href="/propiedades/all"><i class="fas fa-building"></i> Propiedades</a>
+        <a class="nav-link" href="/users/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-users"></i> Usuarios</a>
+        <a class="nav-link" href="/propiedades/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-building"></i> Propiedades</a>
         <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
         <a class="nav-link" href="/propiedad-contrato/all"><i class="fas fa-link"></i> Asignaciones</a>
         <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>

--- a/demo/src/main/resources/templates/propiedades/propiedades.html
+++ b/demo/src/main/resources/templates/propiedades/propiedades.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <head>
     <title>Lista de propiedades</title>
 </head>
 <body>
 <h1>Propiedades registradas</h1>
-<a th:href="@{/propiedades/crear}">Añadir nueva propiedad</a>
+<a th:href="@{/propiedades/crear}" sec:authorize="hasRole('ADMIN')">Añadir nueva propiedad</a>
 <table border="1">
     <thead>
     <tr>
@@ -15,7 +15,7 @@
         <th>Precio</th>
         <th>Estado</th>
         <th>Dueño</th>
-        <th>Acciones</th>
+        <th sec:authorize="hasRole('ADMIN')">Acciones</th>
     </tr>
     </thead>
     <tbody>
@@ -26,7 +26,7 @@
         <td th:text="${propiedad.precio}"></td>
         <td th:text="${propiedad.estado}"></td>
         <td th:text="${propiedad.duenio?.username}"></td>
-        <td>
+        <td sec:authorize="hasRole('ADMIN')">
             <a th:href="@{'/propiedades/editar/' + ${propiedad.id}}">Editar</a> |
             <a th:href="@{'/propiedades/eliminar/' + ${propiedad.id}}"
                onclick="return confirm('¿Está seguro de eliminar esta propiedad?')">Eliminar</a>

--- a/demo/src/main/resources/templates/users/users.html
+++ b/demo/src/main/resources/templates/users/users.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <head>
     <meta charset="UTF-8">
     <title>Lista de Usuarios</title>
@@ -9,7 +9,7 @@
 <body>
 <div class="container mt-5">
     <h1 class="text-center mb-4">Lista de Usuarios</h1>
-    <div class="mb-3 text-right">
+    <div class="mb-3 text-right" sec:authorize="hasRole('ADMIN')">
         <a class="btn btn-success" th:href="@{/users/crear}">Nuevo Usuario</a>
     </div>
     <div th:if="${mensaje != null}" class="alert alert-success" th:text="${mensaje}"></div>
@@ -22,7 +22,7 @@
                 <th>Email</th>
                 <th>Rol</th>
                 <th>Estado</th>
-                <th>Acciones</th>
+                <th sec:authorize="hasRole('ADMIN')">Acciones</th>
             </tr>
             </thead>
             <tbody>
@@ -34,7 +34,7 @@
                 <td>
                     <span class="badge badge-success">Activo</span>
                 </td>
-                <td>
+                <td sec:authorize="hasRole('ADMIN')">
                     <a th:href="@{'/users/editar/' + ${user.username}}" class="btn btn-primary btn-sm">Editar</a>
                     <a th:href="@{'/users/eliminar/' + ${user.username}}"
                        class="btn btn-danger btn-sm"


### PR DESCRIPTION
## Summary
- secure project with Spring Security and in-memory admin user
- restrict `UserController` and `PropiedadController` to ADMIN role
- show admin navigation/actions only to admins in templates
- add Spring Security and Thymeleaf security dependencies

## Testing
- `./mvnw -q test` *(fails: network access needed to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684d5e629008832080e39b6db737fb77