### PR TITLE
Add role checks to controllers

### DIFF
--- a/demo/src/main/java/com/mialquiler/demo/controller/ContratoController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/ContratoController.java
@@ -5,11 +5,13 @@ import com.mialquiler.demo.repository.UserRepository;
 import com.mialquiler.demo.service.ContratoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/contratos")
+@PreAuthorize("hasRole('ADMIN')")
 public class ContratoController {
 
     @Autowired

--- a/demo/src/main/java/com/mialquiler/demo/controller/EstadisticasController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/EstadisticasController.java
@@ -3,11 +3,13 @@ package com.mialquiler.demo.controller;
 import com.mialquiler.demo.service.EstadisticasService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
+@PreAuthorize("hasRole('ADMIN')")
 public class EstadisticasController {
 
     @Autowired

--- a/demo/src/main/java/com/mialquiler/demo/controller/MainController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/MainController.java
@@ -3,11 +3,13 @@ package com.mialquiler.demo.controller;
 import com.mialquiler.demo.service.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
+@PreAuthorize("hasRole('ADMIN')")
 public class MainController {
 
     @Autowired

--- a/demo/src/main/java/com/mialquiler/demo/controller/PagoController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/PagoController.java
@@ -5,11 +5,13 @@ import com.mialquiler.demo.repository.ContratoRepository;
 import com.mialquiler.demo.service.PagoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/pagos")
+@PreAuthorize("hasRole('ADMIN')")
 public class PagoController {
 
     @Autowired

--- a/demo/src/main/java/com/mialquiler/demo/controller/PropiedadContratoController.java
+++ b/demo/src/main/java/com/mialquiler/demo/controller/PropiedadContratoController.java
@@ -7,11 +7,13 @@ import com.mialquiler.demo.repository.PropiedadRepository;
 import com.mialquiler.demo.service.PropiedadContratoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/propiedad-contrato")
+@PreAuthorize("hasRole('ADMIN')")
 public class PropiedadContratoController {
 
     @Autowired


### PR DESCRIPTION
## Summary
- restrict dashboard and contract management endpoints to admins using `@PreAuthorize`

## Testing
- `mvnw test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d61dd52e88320b56bf265532d0552