### PR TITLE
Switch security to DatabaseUserDetailsService

### DIFF
--- a/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
@@ -4,10 +4,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import com.mialquiler.demo.repository.UserRepository;
+import com.mialquiler.demo.security.DatabaseUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -16,13 +17,13 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     @Bean
-    public UserDetailsService userDetailsService() {
-        UserDetails admin = User.withDefaultPasswordEncoder()
-                .username("admin")
-                .password("password")
-                .roles("ADMIN")
-                .build();
-        return new InMemoryUserDetailsManager(admin);
+    public UserDetailsService userDetailsService(UserRepository userRepository) {
+        return new DatabaseUserDetailsService(userRepository);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/demo/src/main/java/com/mialquiler/demo/security/DatabaseUserDetailsService.java
+++ b/demo/src/main/java/com/mialquiler/demo/security/DatabaseUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.mialquiler.demo.security;
+
+import com.mialquiler.demo.entity.Usuario;
+import com.mialquiler.demo.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DatabaseUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public DatabaseUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Usuario usuario = userRepository.findById(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        return User.withUsername(usuario.getUsername())
+                .password(usuario.getContrasenia())
+                .roles(usuario.getRol())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DatabaseUserDetailsService` backed by `UserRepository`
- configure `SecurityConfig` to use the new service and add a `PasswordEncoder`

## Testing
- `sh ./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d67d648208320b19706ee3c387de0