### PR TITLE
Add layout fragments for shared navbar

### DIFF
--- a/demo/src/main/resources/templates/index.html
+++ b/demo/src/main/resources/templates/index.html
@@ -1,28 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
-<head>
-    <meta charset="UTF-8">
-    <title>MiAlquiler - Dashboard</title>
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <!-- Font Awesome para iconos -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-</head>
+<head th:replace="layout :: head"></head>
 <body>
-<!-- Navbar -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <a class="navbar-brand" href="/">
-        <i class="fas fa-home"></i> MiAlquiler
-    </a>
-    <div class="navbar-nav ml-auto">
-        <a class="nav-link" href="/users/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-users"></i> Usuarios</a>
-        <a class="nav-link" href="/propiedades/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-building"></i> Propiedades</a>
-        <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
-        <a class="nav-link" href="/propiedad-contrato/all"><i class="fas fa-link"></i> Asignaciones</a>
-        <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>
-        <a class="nav-link" href="/estadisticas"><i class="fas fa-chart-bar"></i> Estadísticas</a>
-    </div>
-</nav>
+<nav th:replace="layout :: navbar"></nav>
 
 <div class="container-fluid mt-4">
     <div class="row">
@@ -219,10 +199,7 @@
     </div>
 </div>
 
-<!-- Bootstrap JS -->
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<div th:replace="layout :: scripts"></div>
 
 <style>
     .border-left-primary {

--- a/demo/src/main/resources/templates/layout.html
+++ b/demo/src/main/resources/templates/layout.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<head th:fragment="head">
+    <meta charset="UTF-8">
+    <title>MiAlquiler</title>
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+</head>
+<body>
+<nav th:fragment="navbar" class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="/">
+        <i class="fas fa-home"></i> MiAlquiler
+    </a>
+    <div class="navbar-nav ml-auto">
+        <a class="nav-link" href="/users/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-users"></i> Usuarios</a>
+        <a class="nav-link" href="/propiedades/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-building"></i> Propiedades</a>
+        <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
+        <a class="nav-link" href="/propiedad-contrato/all"><i class="fas fa-link"></i> Asignaciones</a>
+        <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>
+        <a class="nav-link" href="/estadisticas"><i class="fas fa-chart-bar"></i> Estadísticas</a>
+    </div>
+</nav>
+<div th:fragment="scripts">
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create shared `layout.html` defining `head`, `navbar` and `scripts` fragments
- reuse these fragments in `index.html`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6e8cbb20832089584c6f54989e88