### PR TITLE
Refactor templates to use common layout

### DIFF
--- a/demo/src/main/resources/templates/contratos/contratoForm.html
+++ b/demo/src/main/resources/templates/contratos/contratoForm.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <title>Formulario de contrato</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Formulario de contrato', ~{::body})">
 <body>
 <h1 th:text="${esEdicion} ? 'Editar contrato' : 'Crear nuevo contrato'">Formulario de contrato</h1>
 <form th:action="${esEdicion} ? @{'/contratos/actualizar/' + ${contrato.id}} : @{/contratos/crear}"

--- a/demo/src/main/resources/templates/contratos/contratos.html
+++ b/demo/src/main/resources/templates/contratos/contratos.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <title>Lista de contratos</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Lista de contratos', ~{::body})">
 <body>
-<h1>Contratos registrados</h1>
+  <h1>Contratos registrados</h1>
 <a th:href="@{/contratos/crear}">Añadir nuevo contrato</a>
 <table border="1">
   <thead>

--- a/demo/src/main/resources/templates/estadisticas/estadisticas.html
+++ b/demo/src/main/resources/templates/estadisticas/estadisticas.html
@@ -1,22 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <title>Estadísticas - MiAlquiler</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-</head>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="layout :: base('Estadísticas - MiAlquiler', ~{::body})">
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <a class="navbar-brand" href="/"><i class="fas fa-home"></i> MiAlquiler</a>
-    <div class="navbar-nav ml-auto">
-        <a class="nav-link" href="/users/all"><i class="fas fa-users"></i> Usuarios</a>
-        <a class="nav-link" href="/propiedades/all"><i class="fas fa-building"></i> Propiedades</a>
-        <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
-        <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>
-        <a class="nav-link active" href="/estadisticas"><i class="fas fa-chart-bar"></i> Estadísticas</a>
-    </div>
-</nav>
 
 <div class="container-fluid mt-4">
     <h1><i class="fas fa-chart-bar"></i> Estadísticas del Sistema</h1>

--- a/demo/src/main/resources/templates/index.html
+++ b/demo/src/main/resources/templates/index.html
@@ -1,28 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
-<head>
-    <meta charset="UTF-8">
-    <title>MiAlquiler - Dashboard</title>
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <!-- Font Awesome para iconos -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-</head>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
+      th:replace="layout :: base('MiAlquiler - Dashboard', ~{::body})">
 <body>
-<!-- Navbar -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <a class="navbar-brand" href="/">
-        <i class="fas fa-home"></i> MiAlquiler
-    </a>
-    <div class="navbar-nav ml-auto">
-        <a class="nav-link" href="/users/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-users"></i> Usuarios</a>
-        <a class="nav-link" href="/propiedades/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-building"></i> Propiedades</a>
-        <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
-        <a class="nav-link" href="/propiedad-contrato/all"><i class="fas fa-link"></i> Asignaciones</a>
-        <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>
-        <a class="nav-link" href="/estadisticas"><i class="fas fa-chart-bar"></i> Estadísticas</a>
-    </div>
-</nav>
 
 <div class="container-fluid mt-4">
     <div class="row">
@@ -219,10 +198,6 @@
     </div>
 </div>
 
-<!-- Bootstrap JS -->
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
 <style>
     .border-left-primary {

--- a/demo/src/main/resources/templates/layout.html
+++ b/demo/src/main/resources/templates/layout.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6" th:fragment="base(title, content)">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${title}">MiAlquiler</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="/">
+        <i class="fas fa-home"></i> MiAlquiler
+    </a>
+    <div class="navbar-nav ml-auto">
+        <a class="nav-link" href="/users/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-users"></i> Usuarios</a>
+        <a class="nav-link" href="/propiedades/all" sec:authorize="hasRole('ADMIN')"><i class="fas fa-building"></i> Propiedades</a>
+        <a class="nav-link" href="/contratos/all"><i class="fas fa-file-contract"></i> Contratos</a>
+        <a class="nav-link" href="/propiedad-contrato/all"><i class="fas fa-link"></i> Asignaciones</a>
+        <a class="nav-link" href="/pagos/all"><i class="fas fa-credit-card"></i> Pagos</a>
+        <a class="nav-link" href="/estadisticas"><i class="fas fa-chart-bar"></i> Estadísticas</a>
+    </div>
+</nav>
+<div th:insert="${content}"></div>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/demo/src/main/resources/templates/pagos/pagoForm.html
+++ b/demo/src/main/resources/templates/pagos/pagoForm.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title th:text="${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago'">Formulario de pago</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base(${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago', ~{::body})">
 <body>
 <h1 th:text="${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago'">Formulario de pago</h1>
 <form th:action="${esEdicion} ? @{'/pagos/actualizar/' + ${pago.id}} : @{/pagos/crear}"

--- a/demo/src/main/resources/templates/pagos/pagos.html
+++ b/demo/src/main/resources/templates/pagos/pagos.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>Lista de pagos</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Lista de pagos', ~{::body})">
 <body>
-<h1>Pagos registrados</h1>
+    <h1>Pagos registrados</h1>
 <a th:href="@{/pagos/crear}">Registrar nuevo pago</a>
 <table border="1">
     <thead>

--- a/demo/src/main/resources/templates/propiedadContrato/formulario.html
+++ b/demo/src/main/resources/templates/propiedadContrato/formulario.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>Formulario Asignación</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Formulario Asignación', ~{::body})">
 <body>
 <h1 th:text="${esEdicion} ? 'Editar Asignación' : 'Nueva Asignación'">Formulario</h1>
 <form th:action="${esEdicion} ? @{'/propiedad-contrato/actualizar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}} : @{/propiedad-contrato/crear}"

--- a/demo/src/main/resources/templates/propiedadContrato/lista.html
+++ b/demo/src/main/resources/templates/propiedadContrato/lista.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>Asignaciones Propiedad-Contrato</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Asignaciones Propiedad-Contrato', ~{::body})">
 <body>
 <h1>Asignaciones de Propiedades a Contratos</h1>
 <a th:href="@{/propiedad-contrato/crear}">Nueva Asignación</a>

--- a/demo/src/main/resources/templates/propiedades/propiedadForm.html
+++ b/demo/src/main/resources/templates/propiedades/propiedadForm.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <title th:text="${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad'">Formulario de propiedad</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base(${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad', ~{::body})">
 <body>
 <h1 th:text="${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad'">Formulario de propiedad</h1>
 <form th:action="${esEdicion} ? @{'/propiedades/actualizar/' + ${propiedad.id}} : @{/propiedades/crear}"

--- a/demo/src/main/resources/templates/propiedades/propiedades.html
+++ b/demo/src/main/resources/templates/propiedades/propiedades.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
-<head>
-    <title>Lista de propiedades</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
+      th:replace="layout :: base('Lista de propiedades', ~{::body})">
 <body>
-<h1>Propiedades registradas</h1>
+    <h1>Propiedades registradas</h1>
 <a th:href="@{/propiedades/crear}" sec:authorize="hasRole('ADMIN')">Añadir nueva propiedad</a>
 <table border="1">
     <thead>

--- a/demo/src/main/resources/templates/users/users.html
+++ b/demo/src/main/resources/templates/users/users.html
@@ -1,13 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
-<head>
-    <meta charset="UTF-8">
-    <title>Lista de Usuarios</title>
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-</head>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
+      th:replace="layout :: base('Lista de Usuarios', ~{::body})">
 <body>
-<div class="container mt-5">
+    <div class="container mt-5">
     <h1 class="text-center mb-4">Lista de Usuarios</h1>
     <div class="mb-3 text-right" sec:authorize="hasRole('ADMIN')">
         <a class="btn btn-success" th:href="@{/users/crear}">Nuevo Usuario</a>

--- a/demo/src/main/resources/templates/users/usersForm.html
+++ b/demo/src/main/resources/templates/users/usersForm.html
@@ -1,11 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8">
-  <title th:text="${esEdicion} ? 'Editar Usuario' : 'Crear Usuario'">Formulario Usuario</title>
-  <!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-</head>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base(${esEdicion} ? 'Editar Usuario' : 'Crear Usuario', ~{::body})">
 <body>
 <div class="container mt-5">
   <h1 class="text-center mb-4" th:text="${esEdicion} ? 'Editar Usuario' : 'Crear Usuario'">Formulario Usuario</h1>


### PR DESCRIPTION
## Summary
- create `layout.html` with navbar and assets
- simplify every template to extend the layout
- drop duplicated head and navbar markup

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6e94df408320a332a1b5b83260b9