### PR TITLE
Improve bootstrap styling in property/contract templates

### DIFF
--- a/demo/src/main/resources/templates/contratos/contratoForm.html
+++ b/demo/src/main/resources/templates/contratos/contratoForm.html
@@ -1,36 +1,42 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Formulario de contrato', ~{::body})">
 <body>
-<h1 th:text="${esEdicion} ? 'Editar contrato' : 'Crear nuevo contrato'">Formulario de contrato</h1>
-<form th:action="${esEdicion} ? @{'/contratos/actualizar/' + ${contrato.id}} : @{/contratos/crear}"
-      th:object="${contrato}" method="post">
-
-  <label>Inquilino:</label>
-  <select th:field="*{inquilino}">
-    <option th:each="usuario : ${usuarios}"
-            th:if="${usuario.rol == 'INQUILINO'}"
-            th:value="${usuario.username}"
-            th:text="${usuario.username}">
-    </option>
-  </select><br/>
-
-  <label>Fecha inicio:</label>
-  <input type="date" th:field="*{fechaInicio}" required/><br/>
-
-  <label>Fecha fin:</label>
-  <input type="date" th:field="*{fechaFin}" required/><br/>
-
-  <label>Precio acordado:</label>
-  <input type="number" step="0.01" th:field="*{precio}" required/><br/>
-
-  <label>Estado:</label>
-  <select th:field="*{estado}">
-    <option th:value="true">Activo</option>
-    <option th:value="false">Inactivo</option>
-  </select><br/>
-
-  <button type="submit" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
-  <a th:href="@{/contratos/all}">Cancelar</a>
-</form>
+<div class="container mt-5">
+    <h1 class="text-center mb-4" th:text="${esEdicion} ? 'Editar contrato' : 'Crear nuevo contrato'">Formulario de contrato</h1>
+    <form th:action="${esEdicion} ? @{'/contratos/actualizar/' + ${contrato.id}} : @{/contratos/crear}"
+          th:object="${contrato}" method="post">
+        <div class="form-group">
+            <label>Inquilino:</label>
+            <select th:field="*{inquilino}" class="form-control">
+                <option th:each="usuario : ${usuarios}"
+                        th:if="${usuario.rol == 'INQUILINO'}"
+                        th:value="${usuario.username}"
+                        th:text="${usuario.username}">
+                </option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Fecha inicio:</label>
+            <input type="date" th:field="*{fechaInicio}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Fecha fin:</label>
+            <input type="date" th:field="*{fechaFin}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Precio acordado:</label>
+            <input type="number" step="0.01" th:field="*{precio}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Estado:</label>
+            <select th:field="*{estado}" class="form-control">
+                <option th:value="true">Activo</option>
+                <option th:value="false">Inactivo</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
+        <a th:href="@{/contratos/all}" class="btn btn-secondary mt-3">Cancelar</a>
+    </form>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/contratos/contratos.html
+++ b/demo/src/main/resources/templates/contratos/contratos.html
@@ -1,35 +1,41 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Lista de contratos', ~{::body})">
 <body>
-  <h1>Contratos registrados</h1>
-<a th:href="@{/contratos/crear}">Añadir nuevo contrato</a>
-<table border="1">
-  <thead>
-  <tr>
-    <th>ID</th>
-    <th>Inquilino</th>
-    <th>Fecha Inicio</th>
-    <th>Fecha Fin</th>
-    <th>Precio</th>
-    <th>Estado</th>
-    <th>Acciones</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr th:each="contrato : ${contratos}">
-    <td th:text="${contrato.id}"></td>
-    <td th:text="${contrato.inquilino?.username}"></td>
-    <td th:text="${contrato.fechaInicio}"></td>
-    <td th:text="${contrato.fechaFin}"></td>
-    <td th:text="${contrato.precio}"></td>
-    <td th:text="${contrato.estado} ? 'Activo' : 'Inactivo'"></td>
-    <td>
-      <a th:href="@{'/contratos/editar/' + ${contrato.id}}">Editar</a> |
-      <a th:href="@{'/contratos/eliminar/' + ${contrato.id}}"
-         onclick="return confirm('¿Está seguro de eliminar este contrato?')">Eliminar</a>
-    </td>
-  </tr>
-  </tbody>
-</table>
+<div class="container mt-5">
+    <h1 class="text-center mb-4">Contratos registrados</h1>
+    <div class="mb-3 text-right">
+        <a th:href="@{/contratos/crear}" class="btn btn-success">Añadir nuevo contrato</a>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>Inquilino</th>
+                <th>Fecha Inicio</th>
+                <th>Fecha Fin</th>
+                <th>Precio</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="contrato : ${contratos}">
+                <td th:text="${contrato.id}"></td>
+                <td th:text="${contrato.inquilino?.username}"></td>
+                <td th:text="${contrato.fechaInicio}"></td>
+                <td th:text="${contrato.fechaFin}"></td>
+                <td th:text="${contrato.precio}"></td>
+                <td th:text="${contrato.estado} ? 'Activo' : 'Inactivo'"></td>
+                <td>
+                    <a th:href="@{'/contratos/editar/' + ${contrato.id}}" class="btn btn-primary btn-sm">Editar</a>
+                    <a th:href="@{'/contratos/eliminar/' + ${contrato.id}}" class="btn btn-danger btn-sm"
+                       onclick="return confirm('¿Está seguro de eliminar este contrato?')">Eliminar</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/pagos/pagoForm.html
+++ b/demo/src/main/resources/templates/pagos/pagoForm.html
@@ -1,40 +1,47 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base(${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago', ~{::body})">
 <body>
-<h1 th:text="${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago'">Formulario de pago</h1>
-<form th:action="${esEdicion} ? @{'/pagos/actualizar/' + ${pago.id}} : @{/pagos/crear}"
-      th:object="${pago}" method="post">
-
-    <label>Contrato:</label>
-    <select th:field="*{contrato}" th:disabled="${esEdicion}" required>
-        <option value="">Seleccione un contrato</option>
-        <option th:each="contrato : ${contratos}"
-                th:value="${contrato.id}"
-                th:text="'Contrato #' + ${contrato.id} + ' - ' + ${contrato.inquilino?.username}"
-                th:selected="${pago.contrato != null && pago.contrato.id == contrato.id}">
-        </option>
-    </select><br/>
-
-    <label>Fecha prevista:</label>
-    <input type="date" th:field="*{fechaPrevista}" required/><br/>
-
-    <label>Fecha real:</label>
-    <input type="date" th:field="*{fechaReal}"/><br/>
-
-    <label>Cantidad esperada:</label>
-    <input type="number" th:field="*{cantidadEsperada}" required/><br/>
-
-    <label>Cantidad abonada:</label>
-    <input type="number" th:field="*{cantidadAbonada}"/><br/>
-
-    <label>Estado:</label>
-    <select th:field="*{estado}">
-        <option th:value="true">Pagado</option>
-        <option th:value="false">Pendiente</option>
-    </select><br/>
-
-    <button type="submit" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
-    <a th:href="@{/pagos/all}">Cancelar</a>
-</form>
+<div class="container mt-5">
+    <h1 class="text-center mb-4" th:text="${esEdicion} ? 'Editar pago' : 'Registrar nuevo pago'">Formulario de pago</h1>
+    <form th:action="${esEdicion} ? @{'/pagos/actualizar/' + ${pago.id}} : @{/pagos/crear}"
+          th:object="${pago}" method="post">
+        <div class="form-group">
+            <label>Contrato:</label>
+            <select th:field="*{contrato}" class="form-control" th:disabled="${esEdicion}" required>
+                <option value="">Seleccione un contrato</option>
+                <option th:each="contrato : ${contratos}"
+                        th:value="${contrato.id}"
+                        th:text="'Contrato #' + ${contrato.id} + ' - ' + ${contrato.inquilino?.username}"
+                        th:selected="${pago.contrato != null && pago.contrato.id == contrato.id}">
+                </option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Fecha prevista:</label>
+            <input type="date" th:field="*{fechaPrevista}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Fecha real:</label>
+            <input type="date" th:field="*{fechaReal}" class="form-control"/>
+        </div>
+        <div class="form-group">
+            <label>Cantidad esperada:</label>
+            <input type="number" th:field="*{cantidadEsperada}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Cantidad abonada:</label>
+            <input type="number" th:field="*{cantidadAbonada}" class="form-control"/>
+        </div>
+        <div class="form-group">
+            <label>Estado:</label>
+            <select th:field="*{estado}" class="form-control">
+                <option th:value="true">Pagado</option>
+                <option th:value="false">Pendiente</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
+        <a th:href="@{/pagos/all}" class="btn btn-secondary mt-3">Cancelar</a>
+    </form>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/pagos/pagos.html
+++ b/demo/src/main/resources/templates/pagos/pagos.html
@@ -1,42 +1,48 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Lista de pagos', ~{::body})">
 <body>
-    <h1>Pagos registrados</h1>
-<a th:href="@{/pagos/crear}">Registrar nuevo pago</a>
-<table border="1">
-    <thead>
-    <tr>
-        <th>ID</th>
-        <th>Contrato</th>
-        <th>Fecha prevista</th>
-        <th>Fecha real</th>
-        <th>Cantidad esperada</th>
-        <th>Cantidad abonada</th>
-        <th>Retraso (días)</th>
-        <th>Estado</th>
-        <th>Acciones</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:each="pago : ${pagos}">
-        <td th:text="${pago.id}">1</td>
-        <td th:text="${pago.contrato != null ? pago.contrato.id : 'N/A'}">Contrato</td>
-        <td th:text="${pago.fechaPrevista}">2025-01-01</td>
-        <td th:text="${pago.fechaReal != null ? pago.fechaReal : 'Pendiente'}">2025-01-02</td>
-        <td th:text="${pago.cantidadEsperada}">500</td>
-        <td th:text="${pago.cantidadAbonada}">500</td>
-        <td th:text="${pago.retraso}">0</td>
-        <td>
-            <span th:if="${pago.estado}" class="badge badge-success">Pagado</span>
-            <span th:if="${!pago.estado}" class="badge badge-danger">Pendiente</span>
-        </td>
-        <td>
-            <a th:href="@{'/pagos/editar/' + ${pago.id}}">Editar</a> |
-            <a th:href="@{'/pagos/eliminar/' + ${pago.id}}"
-               onclick="return confirm('¿Está seguro de eliminar este pago?')">Eliminar</a>
-        </td>
-    </tr>
-    </tbody>
-</table>
+<div class="container mt-5">
+    <h1 class="text-center mb-4">Pagos registrados</h1>
+    <div class="mb-3 text-right">
+        <a th:href="@{/pagos/crear}" class="btn btn-success">Registrar nuevo pago</a>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>Contrato</th>
+                <th>Fecha prevista</th>
+                <th>Fecha real</th>
+                <th>Cantidad esperada</th>
+                <th>Cantidad abonada</th>
+                <th>Retraso (días)</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="pago : ${pagos}">
+                <td th:text="${pago.id}">1</td>
+                <td th:text="${pago.contrato != null ? pago.contrato.id : 'N/A'}">Contrato</td>
+                <td th:text="${pago.fechaPrevista}">2025-01-01</td>
+                <td th:text="${pago.fechaReal != null ? pago.fechaReal : 'Pendiente'}">2025-01-02</td>
+                <td th:text="${pago.cantidadEsperada}">500</td>
+                <td th:text="${pago.cantidadAbonada}">500</td>
+                <td th:text="${pago.retraso}">0</td>
+                <td>
+                    <span th:if="${pago.estado}" class="badge badge-success">Pagado</span>
+                    <span th:if="${!pago.estado}" class="badge badge-danger">Pendiente</span>
+                </td>
+                <td>
+                    <a th:href="@{'/pagos/editar/' + ${pago.id}}" class="btn btn-primary btn-sm">Editar</a>
+                    <a th:href="@{'/pagos/eliminar/' + ${pago.id}}" class="btn btn-danger btn-sm"
+                       onclick="return confirm('¿Está seguro de eliminar este pago?')">Eliminar</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/propiedadContrato/formulario.html
+++ b/demo/src/main/resources/templates/propiedadContrato/formulario.html
@@ -1,42 +1,45 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Formulario Asignación', ~{::body})">
 <body>
-<h1 th:text="${esEdicion} ? 'Editar Asignación' : 'Nueva Asignación'">Formulario</h1>
-<form th:action="${esEdicion} ? @{'/propiedad-contrato/actualizar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}} : @{/propiedad-contrato/crear}"
-      method="post">
-
-    <div th:if="${!esEdicion}">
-        <label>Propiedad:</label>
-        <select name="idPropiedad" required>
-            <option value="">Seleccione una propiedad</option>
-            <option th:each="propiedad : ${propiedades}"
-                    th:value="${propiedad.id}"
-                    th:text="${propiedad.direccion}">
-            </option>
-        </select><br/>
-
-        <label>Contrato:</label>
-        <select name="idContrato" required>
-            <option value="">Seleccione un contrato</option>
-            <option th:each="contrato : ${contratos}"
-                    th:value="${contrato.id}"
-                    th:text="'Contrato #' + ${contrato.id} + ' - ' + ${contrato.inquilino?.username}">
-            </option>
-        </select><br/>
-    </div>
-
-    <div th:if="${esEdicion}">
-        <p><strong>Propiedad:</strong> <span th:text="${asignacion.propiedad.direccion}"></span></p>
-        <p><strong>Contrato:</strong> <span th:text="'#' + ${asignacion.contrato_propiedad.id}"></span></p>
-    </div>
-
-    <label>Estado:</label>
-    <input type="text" name="estado"
-           th:value="${esEdicion} ? ${asignacion.estado} : ''"
-           placeholder="Ej: Activo, En revisión, etc." required/><br/>
-
-    <button type="submit" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
-    <a th:href="@{/propiedad-contrato/all}">Cancelar</a>
-</form>
+<div class="container mt-5">
+    <h1 class="text-center mb-4" th:text="${esEdicion} ? 'Editar Asignación' : 'Nueva Asignación'">Formulario</h1>
+    <form th:action="${esEdicion} ? @{'/propiedad-contrato/actualizar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}} : @{/propiedad-contrato/crear}"
+          method="post">
+        <div th:if="${!esEdicion}">
+            <div class="form-group">
+                <label>Propiedad:</label>
+                <select name="idPropiedad" class="form-control" required>
+                    <option value="">Seleccione una propiedad</option>
+                    <option th:each="propiedad : ${propiedades}"
+                            th:value="${propiedad.id}"
+                            th:text="${propiedad.direccion}">
+                    </option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Contrato:</label>
+                <select name="idContrato" class="form-control" required>
+                    <option value="">Seleccione un contrato</option>
+                    <option th:each="contrato : ${contratos}"
+                            th:value="${contrato.id}"
+                            th:text="'Contrato #' + ${contrato.id} + ' - ' + ${contrato.inquilino?.username}">
+                    </option>
+                </select>
+            </div>
+        </div>
+        <div th:if="${esEdicion}">
+            <p><strong>Propiedad:</strong> <span th:text="${asignacion.propiedad.direccion}"></span></p>
+            <p><strong>Contrato:</strong> <span th:text="'#' + ${asignacion.contrato_propiedad.id}"></span></p>
+        </div>
+        <div class="form-group">
+            <label>Estado:</label>
+            <input type="text" name="estado" class="form-control"
+                   th:value="${esEdicion} ? ${asignacion.estado} : ''"
+                   placeholder="Ej: Activo, En revisión, etc." required/>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
+        <a th:href="@{/propiedad-contrato/all}" class="btn btn-secondary mt-3">Cancelar</a>
+    </form>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/propiedadContrato/lista.html
+++ b/demo/src/main/resources/templates/propiedadContrato/lista.html
@@ -1,29 +1,35 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base('Asignaciones Propiedad-Contrato', ~{::body})">
 <body>
-<h1>Asignaciones de Propiedades a Contratos</h1>
-<a th:href="@{/propiedad-contrato/crear}">Nueva Asignación</a>
-<table border="1">
-    <thead>
-    <tr>
-        <th>Propiedad</th>
-        <th>Contrato</th>
-        <th>Estado</th>
-        <th>Acciones</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:each="asignacion : ${asignaciones}">
-        <td th:text="${asignacion.propiedad.direccion}"></td>
-        <td th:text="'Contrato #' + ${asignacion.contrato_propiedad.id}"></td>
-        <td th:text="${asignacion.estado}"></td>
-        <td>
-            <a th:href="@{'/propiedad-contrato/editar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}}">Editar</a> |
-            <a th:href="@{'/propiedad-contrato/eliminar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}}"
-               onclick="return confirm('¿Está seguro de eliminar esta asignación?')">Eliminar</a>
-        </td>
-    </tr>
-    </tbody>
-</table>
+<div class="container mt-5">
+    <h1 class="text-center mb-4">Asignaciones de Propiedades a Contratos</h1>
+    <div class="mb-3 text-right">
+        <a th:href="@{/propiedad-contrato/crear}" class="btn btn-success">Nueva Asignación</a>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+            <tr>
+                <th>Propiedad</th>
+                <th>Contrato</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="asignacion : ${asignaciones}">
+                <td th:text="${asignacion.propiedad.direccion}"></td>
+                <td th:text="'Contrato #' + ${asignacion.contrato_propiedad.id}"></td>
+                <td th:text="${asignacion.estado}"></td>
+                <td>
+                    <a th:href="@{'/propiedad-contrato/editar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}}" class="btn btn-primary btn-sm">Editar</a>
+                    <a th:href="@{'/propiedad-contrato/eliminar/' + ${asignacion.propiedad.id} + '/' + ${asignacion.contrato_propiedad.id}}" class="btn btn-danger btn-sm"
+                       onclick="return confirm('¿Está seguro de eliminar esta asignación?')">Eliminar</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/propiedades/propiedadForm.html
+++ b/demo/src/main/resources/templates/propiedades/propiedadForm.html
@@ -1,36 +1,42 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: base(${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad', ~{::body})">
 <body>
-<h1 th:text="${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad'">Formulario de propiedad</h1>
-<form th:action="${esEdicion} ? @{'/propiedades/actualizar/' + ${propiedad.id}} : @{/propiedades/crear}"
-      th:object="${propiedad}" method="post">
-
-  <label>Dirección:</label>
-  <input type="text" th:field="*{direccion}" required/><br/>
-
-  <label>Descripción:</label>
-  <textarea th:field="*{descripcion}" rows="3" cols="50"></textarea><br/>
-
-  <label>Precio:</label>
-  <input type="number" th:field="*{precio}" required/><br/>
-
-  <label>Estado:</label>
-  <select th:field="*{estado}" required>
-    <option value="DISPONIBLE">Disponible</option>
-    <option value="OCUPADA">Ocupada</option>
-    <option value="MANTENIMIENTO">En mantenimiento</option>
-  </select><br/>
-
-  <label>Dueño:</label>
-  <select th:field="*{duenio}" required>
-    <option th:each="usuario : ${usuarios}"
-            th:value="${usuario.username}"
-            th:text="${usuario.username + ' - ' + usuario.nombre}">
-    </option>
-  </select><br/>
-
-  <button type="submit" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
-  <a th:href="@{/propiedades/all}">Cancelar</a>
-</form>
+<div class="container mt-5">
+    <h1 class="text-center mb-4" th:text="${esEdicion} ? 'Editar propiedad' : 'Crear nueva propiedad'">Formulario de propiedad</h1>
+    <form th:action="${esEdicion} ? @{'/propiedades/actualizar/' + ${propiedad.id}} : @{/propiedades/crear}"
+          th:object="${propiedad}" method="post">
+        <div class="form-group">
+            <label>Dirección:</label>
+            <input type="text" th:field="*{direccion}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Descripción:</label>
+            <textarea th:field="*{descripcion}" class="form-control" rows="3"></textarea>
+        </div>
+        <div class="form-group">
+            <label>Precio:</label>
+            <input type="number" th:field="*{precio}" class="form-control" required/>
+        </div>
+        <div class="form-group">
+            <label>Estado:</label>
+            <select th:field="*{estado}" class="form-control" required>
+                <option value="DISPONIBLE">Disponible</option>
+                <option value="OCUPADA">Ocupada</option>
+                <option value="MANTENIMIENTO">En mantenimiento</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Dueño:</label>
+            <select th:field="*{duenio}" class="form-control" required>
+                <option th:each="usuario : ${usuarios}"
+                        th:value="${usuario.username}"
+                        th:text="${usuario.username + ' - ' + usuario.nombre}">
+                </option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3" th:text="${esEdicion} ? 'Actualizar' : 'Guardar'">Guardar</button>
+        <a th:href="@{/propiedades/all}" class="btn btn-secondary mt-3">Cancelar</a>
+    </form>
+</div>
 </body>
 </html>

--- a/demo/src/main/resources/templates/propiedades/propiedades.html
+++ b/demo/src/main/resources/templates/propiedades/propiedades.html
@@ -2,35 +2,41 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
       th:replace="layout :: base('Lista de propiedades', ~{::body})">
 <body>
-    <h1>Propiedades registradas</h1>
-<a th:href="@{/propiedades/crear}" sec:authorize="hasRole('ADMIN')">Añadir nueva propiedad</a>
-<table border="1">
-    <thead>
-    <tr>
-        <th>ID</th>
-        <th>Dirección</th>
-        <th>Descripción</th>
-        <th>Precio</th>
-        <th>Estado</th>
-        <th>Dueño</th>
-        <th sec:authorize="hasRole('ADMIN')">Acciones</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:each="propiedad : ${propiedades}">
-        <td th:text="${propiedad.id}"></td>
-        <td th:text="${propiedad.direccion}"></td>
-        <td th:text="${propiedad.descripcion}"></td>
-        <td th:text="${propiedad.precio}"></td>
-        <td th:text="${propiedad.estado}"></td>
-        <td th:text="${propiedad.duenio?.username}"></td>
-        <td sec:authorize="hasRole('ADMIN')">
-            <a th:href="@{'/propiedades/editar/' + ${propiedad.id}}">Editar</a> |
-            <a th:href="@{'/propiedades/eliminar/' + ${propiedad.id}}"
-               onclick="return confirm('¿Está seguro de eliminar esta propiedad?')">Eliminar</a>
-        </td>
-    </tr>
-    </tbody>
-</table>
+<div class="container mt-5">
+    <h1 class="text-center mb-4">Propiedades registradas</h1>
+    <div class="mb-3 text-right" sec:authorize="hasRole('ADMIN')">
+        <a th:href="@{/propiedades/crear}" class="btn btn-success">Añadir nueva propiedad</a>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>Dirección</th>
+                <th>Descripción</th>
+                <th>Precio</th>
+                <th>Estado</th>
+                <th>Dueño</th>
+                <th sec:authorize="hasRole('ADMIN')">Acciones</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="propiedad : ${propiedades}">
+                <td th:text="${propiedad.id}"></td>
+                <td th:text="${propiedad.direccion}"></td>
+                <td th:text="${propiedad.descripcion}"></td>
+                <td th:text="${propiedad.precio}"></td>
+                <td th:text="${propiedad.estado}"></td>
+                <td th:text="${propiedad.duenio?.username}"></td>
+                <td sec:authorize="hasRole('ADMIN')">
+                    <a th:href="@{'/propiedades/editar/' + ${propiedad.id}}" class="btn btn-primary btn-sm">Editar</a>
+                    <a th:href="@{'/propiedades/eliminar/' + ${propiedad.id}}" class="btn btn-danger btn-sm"
+                       onclick="return confirm('¿Está seguro de eliminar esta propiedad?')">Eliminar</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh property list and form pages with Bootstrap
- update contract list and form pages
- style payment list and form pages
- modernize propiedad-contrato templates

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7283142c8320b54bd00c0d1a6c5b