### PR TITLE
Fix login failure by removing duplicate UserDetailsService

### DIFF
--- a/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/mialquiler/demo/config/SecurityConfig.java
@@ -4,9 +4,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import com.mialquiler.demo.repository.UserRepository;
-import com.mialquiler.demo.security.DatabaseUserDetailsService;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,11 +12,6 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
-
-    @Bean
-    public UserDetailsService userDetailsService(UserRepository userRepository) {
-        return new DatabaseUserDetailsService(userRepository);
-    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {


### PR DESCRIPTION
## Summary
- remove custom `UserDetailsService` bean definition

This avoids conflicting bean definitions so Spring Security can create a `DaoAuthenticationProvider` for username/password login.

## Testing
- `mvn -q -DskipTests spring-boot:run` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc4dcbcac8320839f10be2b6a1a05