### PR TITLE
Add missing service unit tests

### DIFF
--- a/demo/src/test/java/com/mialquiler/demo/service/ContratoServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/ContratoServiceTest.java
@@ -1,0 +1,115 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Contrato;
+import com.mialquiler.demo.repository.ContratoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContratoServiceTest {
+
+    @Mock
+    private ContratoRepository contratoRepository;
+
+    @Mock
+    private NotificacionesService notificacionesService;
+
+    @InjectMocks
+    private ContratoService contratoService;
+
+    private Contrato contrato;
+
+    @BeforeEach
+    void setUp() {
+        contrato = new Contrato();
+        contrato.setId(1L);
+    }
+
+    @Test
+    void listarTodos_deberiaDevolverLista() {
+        when(contratoRepository.findAll()).thenReturn(List.of(contrato));
+
+        List<Contrato> resultado = contratoService.listarTodos();
+
+        assertEquals(1, resultado.size());
+        verify(contratoRepository).findAll();
+    }
+
+    @Test
+    void guardar_deberiaInvocarRepositorio() {
+        contratoService.guardar(contrato);
+        verify(contratoRepository).save(contrato);
+    }
+
+    @Test
+    void buscarPorId_existente_deberiaDevolverOptional() {
+        when(contratoRepository.findById(1L)).thenReturn(Optional.of(contrato));
+
+        Optional<Contrato> resultado = contratoService.buscarPorId(1L);
+
+        assertTrue(resultado.isPresent());
+        verify(contratoRepository).findById(1L);
+    }
+
+    @Test
+    void buscarPorId_noExistente_deberiaDevolverVacio() {
+        when(contratoRepository.findById(2L)).thenReturn(Optional.empty());
+
+        Optional<Contrato> resultado = contratoService.buscarPorId(2L);
+
+        assertTrue(resultado.isEmpty());
+        verify(contratoRepository).findById(2L);
+    }
+
+    @Test
+    void actualizar_cuandoExiste_deberiaGuardar() {
+        when(contratoRepository.existsById(contrato.getId())).thenReturn(true);
+
+        contratoService.actualizar(contrato);
+
+        verify(contratoRepository).save(contrato);
+    }
+
+    @Test
+    void actualizar_cuandoNoExiste_deberiaLanzarExcepcion() {
+        when(contratoRepository.existsById(contrato.getId())).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> contratoService.actualizar(contrato));
+    }
+
+    @Test
+    void eliminar_deberiaInvocarRepositorio() {
+        contratoService.eliminar(1L);
+        verify(contratoRepository).deleteById(1L);
+    }
+
+    @Test
+    void contratosPorVencer_deberiaRetornarListaDeServicioNotificaciones() {
+        when(notificacionesService.getContratosPorVencer()).thenReturn(List.of(contrato));
+
+        List<Contrato> resultado = contratoService.contratosPorVencer();
+
+        assertEquals(1, resultado.size());
+        verify(notificacionesService).getContratosPorVencer();
+    }
+
+    @Test
+    void listarContratosPorUsuario_deberiaInvocarRepositorio() {
+        when(contratoRepository.findByInquilino_Username("user")).thenReturn(List.of(contrato));
+
+        List<Contrato> resultado = contratoService.listarContratosPorUsuario("user");
+
+        assertEquals(1, resultado.size());
+        verify(contratoRepository).findByInquilino_Username("user");
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/EstadisticasServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/EstadisticasServiceTest.java
@@ -1,0 +1,93 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.repository.ContratoRepository;
+import com.mialquiler.demo.repository.PagoRepository;
+import com.mialquiler.demo.repository.PropiedadRepository;
+import com.mialquiler.demo.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EstadisticasServiceTest {
+
+    @Mock
+    private PropiedadRepository propiedadRepository;
+    @Mock
+    private ContratoRepository contratoRepository;
+    @Mock
+    private PagoRepository pagoRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private EstadisticasService estadisticasService;
+
+    @Test
+    void contarPropiedadesDisponibles_deberiaConsultarRepositorio() {
+        when(propiedadRepository.countByEstado("DISPONIBLE")).thenReturn(3L);
+
+        long total = estadisticasService.contarPropiedadesDisponibles();
+
+        assertEquals(3L, total);
+        verify(propiedadRepository).countByEstado("DISPONIBLE");
+    }
+
+    @Test
+    void contarPropiedadesOcupadas_deberiaConsultarRepositorio() {
+        when(propiedadRepository.countByEstado("OCUPADA")).thenReturn(2L);
+
+        long total = estadisticasService.contarPropiedadesOcupadas();
+
+        assertEquals(2L, total);
+        verify(propiedadRepository).countByEstado("OCUPADA");
+    }
+
+    @Test
+    void contarContratosPorVencer30Dias_deberiaConsultarRepositorio() {
+        when(contratoRepository.countByFechaFinBetween(any(LocalDate.class), any(LocalDate.class))).thenReturn(1L);
+
+        long total = estadisticasService.contarContratosPorVencer30Dias();
+
+        assertEquals(1L, total);
+        verify(contratoRepository).countByFechaFinBetween(any(LocalDate.class), any(LocalDate.class));
+    }
+
+    @Test
+    void calcularIngresosMensuales_deberiaConsultarRepositorio() {
+        when(contratoRepository.sumPrecioByEstadoTrue()).thenReturn(1000.0);
+
+        Double total = estadisticasService.calcularIngresosMensuales();
+
+        assertEquals(1000.0, total);
+        verify(contratoRepository).sumPrecioByEstadoTrue();
+    }
+
+    @Test
+    void contarContratosPorAnio_deberiaConsultarRepositorio() {
+        when(contratoRepository.countByFechaInicioBetween(any(LocalDate.class), any(LocalDate.class))).thenReturn(5L);
+
+        long total = estadisticasService.contarContratosPorAnio(2024);
+
+        assertEquals(5L, total);
+        verify(contratoRepository).countByFechaInicioBetween(any(LocalDate.class), any(LocalDate.class));
+    }
+
+    @Test
+    void contarPagosSuperioresA_deberiaConsultarRepositorio() {
+        when(pagoRepository.countByCantidadEsperadaGreaterThan(100)).thenReturn(4L);
+
+        long total = estadisticasService.contarPagosSuperioresA(100);
+
+        assertEquals(4L, total);
+        verify(pagoRepository).countByCantidadEsperadaGreaterThan(100);
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/NotificacionesServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/NotificacionesServiceTest.java
@@ -1,0 +1,91 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Contrato;
+import com.mialquiler.demo.entity.Pago;
+import com.mialquiler.demo.repository.ContratoRepository;
+import com.mialquiler.demo.repository.PagoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificacionesServiceTest {
+
+    @Mock
+    private ContratoRepository contratoRepository;
+    @Mock
+    private PagoRepository pagoRepository;
+    @InjectMocks
+    private NotificacionesService notificacionesService;
+
+    private Contrato contratoVigente;
+    private Contrato contratoFueraRango;
+    private Pago pagoAtrasado;
+    private Pago pagoPorVencer;
+
+    @BeforeEach
+    void setUp() {
+        contratoVigente = new Contrato();
+        contratoVigente.setFechaFin(LocalDate.now().plusDays(10));
+        contratoFueraRango = new Contrato();
+        contratoFueraRango.setFechaFin(LocalDate.now().plusDays(40));
+
+        pagoAtrasado = new Pago();
+        pagoAtrasado.setEstado(false);
+        pagoAtrasado.setFechaPrevista(LocalDate.now().minusDays(5));
+
+        pagoPorVencer = new Pago();
+        pagoPorVencer.setEstado(false);
+        pagoPorVencer.setFechaPrevista(LocalDate.now().plusDays(3));
+    }
+
+    @Test
+    void getContratosPorVencer_deberiaFiltrarCorrectamente() {
+        when(contratoRepository.findAll()).thenReturn(List.of(contratoVigente, contratoFueraRango));
+
+        List<Contrato> resultado = notificacionesService.getContratosPorVencer();
+
+        assertEquals(1, resultado.size());
+        assertTrue(resultado.contains(contratoVigente));
+    }
+
+    @Test
+    void getPagosAtrasados_deberiaFiltrarCorrectamente() {
+        when(pagoRepository.findAll()).thenReturn(List.of(pagoAtrasado, pagoPorVencer));
+
+        List<Pago> resultado = notificacionesService.getPagosAtrasados();
+
+        assertEquals(1, resultado.size());
+        assertTrue(resultado.contains(pagoAtrasado));
+    }
+
+    @Test
+    void getPagosPorVencer_deberiaFiltrarCorrectamente() {
+        when(pagoRepository.findAll()).thenReturn(List.of(pagoAtrasado, pagoPorVencer));
+
+        List<Pago> resultado = notificacionesService.getPagosPorVencer();
+
+        assertEquals(1, resultado.size());
+        assertTrue(resultado.contains(pagoPorVencer));
+    }
+
+    @Test
+    void calcularRetraso_deberiaCalcularDias() {
+        Pago pago = new Pago();
+        pago.setFechaPrevista(LocalDate.now().minusDays(3));
+        pago.setFechaReal(LocalDate.now());
+
+        int dias = notificacionesService.calcularRetraso(pago);
+
+        assertEquals(3, dias);
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/PagoServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/PagoServiceTest.java
@@ -1,0 +1,115 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Pago;
+import com.mialquiler.demo.repository.PagoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PagoServiceTest {
+
+    @Mock
+    private PagoRepository pagoRepository;
+
+    @Mock
+    private NotificacionesService notificacionesService;
+
+    @InjectMocks
+    private PagoService pagoService;
+
+    private Pago pago;
+
+    @BeforeEach
+    void setUp() {
+        pago = new Pago();
+        pago.setId(1L);
+        pago.setFechaPrevista(LocalDate.now().minusDays(2));
+        pago.setEstado(false);
+    }
+
+    @Test
+    void listarTodos_deberiaCalcularRetraso() {
+        when(pagoRepository.findAll()).thenReturn(List.of(pago));
+        when(notificacionesService.calcularRetraso(pago)).thenReturn(2);
+
+        List<Pago> resultado = pagoService.listarTodos();
+
+        assertEquals(2, resultado.get(0).getRetraso());
+        verify(pagoRepository).findAll();
+    }
+
+    @Test
+    void guardar_deberiaCalcularRetrasoYGuardar() {
+        when(notificacionesService.calcularRetraso(pago)).thenReturn(3);
+
+        pagoService.guardar(pago);
+
+        assertEquals(3, pago.getRetraso());
+        verify(pagoRepository).save(pago);
+    }
+
+    @Test
+    void buscarPorId_existente_deberiaDevolverOptional() {
+        when(pagoRepository.findById(1L)).thenReturn(Optional.of(pago));
+
+        Optional<Pago> resultado = pagoService.buscarPorId(1L);
+
+        assertTrue(resultado.isPresent());
+        verify(pagoRepository).findById(1L);
+    }
+
+    @Test
+    void buscarPorId_noExistente_deberiaDevolverVacio() {
+        when(pagoRepository.findById(2L)).thenReturn(Optional.empty());
+
+        Optional<Pago> resultado = pagoService.buscarPorId(2L);
+
+        assertTrue(resultado.isEmpty());
+        verify(pagoRepository).findById(2L);
+    }
+
+    @Test
+    void actualizar_cuandoExiste_deberiaGuardar() {
+        when(pagoRepository.existsById(pago.getId())).thenReturn(true);
+        when(notificacionesService.calcularRetraso(pago)).thenReturn(1);
+
+        pagoService.actualizar(pago);
+
+        verify(pagoRepository).save(pago);
+        assertEquals(1, pago.getRetraso());
+    }
+
+    @Test
+    void actualizar_cuandoNoExiste_deberiaLanzarExcepcion() {
+        when(pagoRepository.existsById(pago.getId())).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> pagoService.actualizar(pago));
+    }
+
+    @Test
+    void eliminar_deberiaInvocarRepositorio() {
+        pagoService.eliminar(1L);
+        verify(pagoRepository).deleteById(1L);
+    }
+
+    @Test
+    void pagosAtrasados_deberiaRetornarListaDeServicioNotificaciones() {
+        when(notificacionesService.getPagosAtrasados()).thenReturn(List.of(pago));
+
+        List<Pago> resultado = pagoService.pagosAtrasados();
+
+        assertEquals(1, resultado.size());
+        verify(notificacionesService).getPagosAtrasados();
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/PerfilServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/PerfilServiceTest.java
@@ -1,0 +1,115 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Perfil;
+import com.mialquiler.demo.entity.Usuario;
+import com.mialquiler.demo.repository.PerfilRepository;
+import com.mialquiler.demo.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PerfilServiceTest {
+
+    @Mock
+    private PerfilRepository perfilRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PerfilService perfilService;
+
+    private Perfil perfil;
+
+    @BeforeEach
+    void setUp() {
+        perfil = new Perfil();
+        perfil.setId(1L);
+        perfil.setNombre("ADMIN");
+    }
+
+    @Test
+    void listarTodos_deberiaDevolverLista() {
+        when(perfilRepository.findAll()).thenReturn(List.of(perfil));
+
+        List<Perfil> resultado = perfilService.listarTodos();
+
+        assertEquals(1, resultado.size());
+        verify(perfilRepository).findAll();
+    }
+
+    @Test
+    void guardar_deberiaInvocarRepositorio() {
+        perfilService.guardar(perfil);
+        verify(perfilRepository).save(perfil);
+    }
+
+    @Test
+    void buscarPorId_existente_deberiaDevolverOptional() {
+        when(perfilRepository.findById(1L)).thenReturn(Optional.of(perfil));
+
+        Optional<Perfil> resultado = perfilService.buscarPorId(1L);
+
+        assertTrue(resultado.isPresent());
+        verify(perfilRepository).findById(1L);
+    }
+
+    @Test
+    void buscarPorId_noExistente_deberiaDevolverVacio() {
+        when(perfilRepository.findById(2L)).thenReturn(Optional.empty());
+
+        Optional<Perfil> resultado = perfilService.buscarPorId(2L);
+
+        assertTrue(resultado.isEmpty());
+        verify(perfilRepository).findById(2L);
+    }
+
+    @Test
+    void actualizar_cuandoExiste_deberiaGuardar() {
+        when(perfilRepository.existsById(perfil.getId())).thenReturn(true);
+
+        perfilService.actualizar(perfil);
+
+        verify(perfilRepository).save(perfil);
+    }
+
+    @Test
+    void actualizar_cuandoNoExiste_deberiaLanzarExcepcion() {
+        when(perfilRepository.existsById(perfil.getId())).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> perfilService.actualizar(perfil));
+    }
+
+    @Test
+    void eliminar_deberiaInvocarRepositorio() {
+        perfilService.eliminar(1L);
+        verify(perfilRepository).deleteById(1L);
+    }
+
+    @Test
+    void asignarPerfilAUsuario_deberiaActualizarRolYGuardarUsuario() {
+        Usuario usuario = new Usuario();
+        usuario.setUsername("user");
+        usuario.setContrasenia("pass");
+
+        when(userRepository.findById("user")).thenReturn(Optional.of(usuario));
+        when(perfilRepository.findById(1L)).thenReturn(Optional.of(perfil));
+        when(userRepository.save(any(Usuario.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        Usuario resultado = perfilService.asignarPerfilAUsuario("user", 1L);
+
+        assertEquals(perfil, resultado.getPerfil());
+        assertEquals("ADMIN", resultado.getRol());
+        verify(userRepository).save(resultado);
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/PropiedadContratoServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/PropiedadContratoServiceTest.java
@@ -1,0 +1,114 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Contrato;
+import com.mialquiler.demo.entity.Propiedad;
+import com.mialquiler.demo.entity.PropiedadContrato;
+import com.mialquiler.demo.entity.PropiedadContratoId;
+import com.mialquiler.demo.repository.ContratoRepository;
+import com.mialquiler.demo.repository.PropiedadContratoRepository;
+import com.mialquiler.demo.repository.PropiedadRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PropiedadContratoServiceTest {
+
+    @Mock
+    private PropiedadContratoRepository propiedadContratoRepository;
+
+    @Mock
+    private PropiedadRepository propiedadRepository;
+
+    @Mock
+    private ContratoRepository contratoRepository;
+
+    @InjectMocks
+    private PropiedadContratoService propiedadContratoService;
+
+    private Propiedad propiedad;
+    private Contrato contrato;
+    private PropiedadContrato pc;
+
+    @BeforeEach
+    void setUp() {
+        propiedad = new Propiedad();
+        propiedad.setId(1L);
+        contrato = new Contrato();
+        contrato.setId(2L);
+
+        PropiedadContratoId id = new PropiedadContratoId();
+        id.setId_propiedad(1L);
+        id.setId_contrato(2L);
+
+        pc = new PropiedadContrato();
+        pc.setId(id);
+        pc.setPropiedad(propiedad);
+        pc.setContrato_propiedad(contrato);
+        pc.setEstado("ACTIVO");
+    }
+
+    @Test
+    void listarTodas_deberiaDevolverLista() {
+        when(propiedadContratoRepository.findAll()).thenReturn(List.of(pc));
+
+        List<PropiedadContrato> resultado = propiedadContratoService.listarTodas();
+
+        assertEquals(1, resultado.size());
+        verify(propiedadContratoRepository).findAll();
+    }
+
+    @Test
+    void crear_deberiaGuardarAsignacion() {
+        when(propiedadRepository.findById(1L)).thenReturn(Optional.of(propiedad));
+        when(contratoRepository.findById(2L)).thenReturn(Optional.of(contrato));
+
+        propiedadContratoService.crear(1L, 2L, "ACTIVO");
+
+        verify(propiedadContratoRepository).save(any(PropiedadContrato.class));
+    }
+
+    @Test
+    void buscarPorId_deberiaUsarRepositorio() {
+        PropiedadContratoId id = new PropiedadContratoId();
+        id.setId_propiedad(1L);
+        id.setId_contrato(2L);
+        when(propiedadContratoRepository.findById(id)).thenReturn(Optional.of(pc));
+
+        Optional<PropiedadContrato> resultado = propiedadContratoService.buscarPorId(1L,2L);
+
+        assertTrue(resultado.isPresent());
+        verify(propiedadContratoRepository).findById(id);
+    }
+
+    @Test
+    void actualizar_deberiaCambiarEstado() {
+        PropiedadContratoId id = pc.getId();
+        when(propiedadContratoRepository.findById(id)).thenReturn(Optional.of(pc));
+
+        propiedadContratoService.actualizar(1L,2L,"INACTIVO");
+
+        assertEquals("INACTIVO", pc.getEstado());
+        verify(propiedadContratoRepository).save(pc);
+    }
+
+    @Test
+    void eliminar_deberiaInvocarRepositorio() {
+        PropiedadContratoId id = new PropiedadContratoId();
+        id.setId_propiedad(1L);
+        id.setId_contrato(2L);
+
+        propiedadContratoService.eliminar(1L,2L);
+
+        verify(propiedadContratoRepository).deleteById(id);
+    }
+}

--- a/demo/src/test/java/com/mialquiler/demo/service/PropiedadServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/PropiedadServiceTest.java
@@ -70,18 +70,16 @@ class PropiedadServiceTest {
     }
 
     @Test
-    void testGet_WhenPropiedadNotExists_ShouldThrowException() {
+    void testGet_WhenPropiedadNotExists_ShouldReturnEmptyOptional() {
         // --- ARRANGE ---
         // Se simula que el repositorio NO encuentra la propiedad
         when(propiedadRepository.findById(99L)).thenReturn(Optional.empty());
 
-        // --- ACT & ASSERT ---
-        // Se comprueba que tu método get() lanza una excepción cuando no encuentra
-        // la propiedad, porque internamente está usando .get() sobre un Optional vacío.
-        // Esto es correcto y demuestra que el test funciona.
-        assertThrows(NoSuchElementException.class, () -> {
-            propiedadService.buscarPorId(99L);
-        });
+        // --- ACT ---
+        Optional<Propiedad> resultado = propiedadService.buscarPorId(99L);
+
+        // --- ASSERT ---
+        assertTrue(resultado.isEmpty());
         verify(propiedadRepository).findById(99L);
     }
 
@@ -96,6 +94,22 @@ class PropiedadServiceTest {
         // --- ASSERT ---
         // Se verifica que el método save() del repositorio fue llamado con el objeto propiedad1
         verify(propiedadRepository).save(propiedad1);
+    }
+
+    @Test
+    void testActualizar_CuandoExiste_DeberiaGuardar() {
+        when(propiedadRepository.existsById(propiedad1.getId())).thenReturn(true);
+
+        propiedadService.actualizar(propiedad1);
+
+        verify(propiedadRepository).save(propiedad1);
+    }
+
+    @Test
+    void testActualizar_CuandoNoExiste_DeberiaLanzarExcepcion() {
+        when(propiedadRepository.existsById(propiedad1.getId())).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> propiedadService.actualizar(propiedad1));
     }
 
     @Test

--- a/demo/src/test/java/com/mialquiler/demo/service/UserServiceTest.java
+++ b/demo/src/test/java/com/mialquiler/demo/service/UserServiceTest.java
@@ -1,0 +1,135 @@
+package com.mialquiler.demo.service;
+
+import com.mialquiler.demo.entity.Usuario;
+import com.mialquiler.demo.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setUsername("user");
+        usuario.setContrasenia("pass");
+    }
+
+    @Test
+    void cambiarRolToPropietario_deberiaGuardarUsuario() {
+        Usuario result = userService.cambiarRolToPropietario(usuario);
+        assertEquals("PROPIETARIO", result.getRol());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void cambiarRolToInquilino_deberiaGuardarUsuario() {
+        Usuario result = userService.cambiarRolToInquilino(usuario);
+        assertEquals("INQUILINO", result.getRol());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void validarUsername_cuandoNoExiste_deberiaGuardar() {
+        when(userRepository.findById("user")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("pass")).thenReturn("hash");
+
+        boolean valido = userService.validarUsername(usuario);
+
+        assertTrue(valido);
+        assertEquals("hash", usuario.getContrasenia());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void validarUsername_cuandoExiste_deberiaRetornarFalse() {
+        when(userRepository.findById("user")).thenReturn(Optional.of(new Usuario()));
+
+        boolean valido = userService.validarUsername(usuario);
+
+        assertFalse(valido);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void actualizar_conNuevaContrasena_deberiaCodificarYGuardar() {
+        when(userRepository.existsById("user")).thenReturn(true);
+        when(passwordEncoder.encode("pass")).thenReturn("hash");
+
+        userService.actualizar(usuario);
+
+        assertEquals("hash", usuario.getContrasenia());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void actualizar_sinNuevaContrasena_deberiaMantenerAnterior() {
+        usuario.setContrasenia("");
+        Usuario existente = new Usuario();
+        existente.setUsername("user");
+        existente.setContrasenia("old");
+
+        when(userRepository.existsById("user")).thenReturn(true);
+        when(userRepository.findById("user")).thenReturn(Optional.of(existente));
+
+        userService.actualizar(usuario);
+
+        assertEquals("old", usuario.getContrasenia());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void actualizar_usuarioNoExiste_deberiaLanzarExcepcion() {
+        when(userRepository.existsById("user")).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> userService.actualizar(usuario));
+    }
+
+    @Test
+    void eliminar_cuandoExiste_deberiaMarcarEliminado() {
+        when(userRepository.findById("user")).thenReturn(Optional.of(usuario));
+
+        userService.eliminar("user");
+
+        assertTrue(usuario.isEliminado());
+        verify(userRepository).save(usuario);
+    }
+
+    @Test
+    void eliminar_usuarioNoExiste_deberiaLanzarExcepcion() {
+        when(userRepository.findById("user")).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> userService.eliminar("user"));
+    }
+
+    @Test
+    void contarUsuarios_deberiaRetornarDelRepositorio() {
+        when(userRepository.count()).thenReturn(5L);
+
+        long total = userService.contarUsuarios();
+
+        assertEquals(5L, total);
+        verify(userRepository).count();
+    }
+}


### PR DESCRIPTION
## Summary
- fix incorrect expectation in `PropiedadServiceTest`
- add tests for all services: `ContratoService`, `PagoService`, `PerfilService`, `UserService`, `PropiedadContratoService`, `NotificacionesService`, and `EstadisticasService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684fd647df60832092c51f775715f368